### PR TITLE
Support running Wine through wrappers

### DIFF
--- a/AstroTuxLauncher.py
+++ b/AstroTuxLauncher.py
@@ -318,7 +318,7 @@ class AstroTuxLauncher():
         timeout = self.config.WineBootTimeout
         cmd = [self.wineexec, "wineboot"]
 
-        if self.config.WrapperPath is not None and self.config.WrapperPath is not "":
+        if self.config.WrapperPath:
             cmd.insert(0, self.config.WrapperPath)
 
         env = os.environ.copy()

--- a/AstroTuxLauncher.py
+++ b/AstroTuxLauncher.py
@@ -136,7 +136,9 @@ class LauncherConfig:
     ServerStatusInterval: float = 3             # Time to wait between Server Status checks
     
     DisableEncryption: bool = True  # Wether to disable encryption for the Astroneer DS. CURRENTLY REQUIRED TO BE "True" FOR HOSTING ON LINUX
-        
+
+    WrapperPath: Optional[str] = field(metadata=config(exclude=ExcludeIfNone), default=None) # Optional wrapper to run Wine with (e.g. box64)
+
     @staticmethod
     def ensure_toml_config(config_path):
         """
@@ -315,6 +317,10 @@ class AstroTuxLauncher():
         LOGGER.debug("Ensuring WINE prefix is setup...")
         timeout = self.config.WineBootTimeout
         cmd = [self.wineexec, "wineboot"]
+
+        if self.config.WrapperPath is not None and self.config.WrapperPath is not "":
+            cmd.insert(0, self.config.WrapperPath)
+
         env = os.environ.copy()
         
         # Remove DISPLAY environment variable to stop wine from creating a window

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ ServerStatusInterval = 3.0
 # (Boolean) Wether to force disable encryption for the Dedicated Server
 DisableEncryption = true
 
+# (Optional, Path as String) Path to executable of a wrapper for Wine (e.g. Box64)
+WrapperPath = # Not set by default
+
 
 # Settings related to sending notifications to external services
 [launcher.notifications]

--- a/astro/dedicatedserver.py
+++ b/astro/dedicatedserver.py
@@ -883,6 +883,10 @@ class AstroDedicatedServer:
         LOGGER.debug("Starting Dedicated Server process...")
         
         cmd = [self.wine_exec, path.join(self.astro_path, "AstroServer.exe"), "-log"]
+
+        if self.launcher.config.WrapperPath is not None and self.launcher.config.WrapperPath is not "":
+            cmd.insert(0, self.launcher.config.WrapperPath)
+
         env = os.environ.copy()
         env["WINEPREFIX"] = self.wine_pfx
         
@@ -903,6 +907,10 @@ class AstroDedicatedServer:
             self.process_out_thread.stop()
         
         cmd = [self.wineserver_exec, "-k", "-w"]
+
+        if self.launcher.config.WrapperPath is not None and self.launcher.config.WrapperPath is not "":
+            cmd.insert(0, self.launcher.config.WrapperPath)
+
         env = os.environ.copy()
         env["WINEPREFIX"] = self.wine_pfx
         

--- a/astro/dedicatedserver.py
+++ b/astro/dedicatedserver.py
@@ -884,7 +884,7 @@ class AstroDedicatedServer:
         
         cmd = [self.wine_exec, path.join(self.astro_path, "AstroServer.exe"), "-log"]
 
-        if self.launcher.config.WrapperPath is not None and self.launcher.config.WrapperPath is not "":
+        if self.launcher.config.WrapperPath:
             cmd.insert(0, self.launcher.config.WrapperPath)
 
         env = os.environ.copy()
@@ -908,7 +908,7 @@ class AstroDedicatedServer:
         
         cmd = [self.wineserver_exec, "-k", "-w"]
 
-        if self.launcher.config.WrapperPath is not None and self.launcher.config.WrapperPath is not "":
+        if self.launcher.config.WrapperPath:
             cmd.insert(0, self.launcher.config.WrapperPath)
 
         env = os.environ.copy()


### PR DESCRIPTION
This PR adds support for running Wine through a wrapper. All it really does is add a new configuration option (`WrapperPath`). If set, it will prefix all Wine commands with `WrapperPath`, allowing Wine to be run through box64 for example.

Fixes #16 